### PR TITLE
Feature/daef 212 disabled options for select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+## vNEXT
+=======
+
+### Features
+
+- Allow to render disabled options in select component
+
+## 0.1.0
+
+Initial release with basic features.

--- a/source/skins/simple/SelectSkin.js
+++ b/source/skins/simple/SelectSkin.js
@@ -51,8 +51,9 @@ class SelectSkin extends Component {
                   theme.option,
                   component.isSelectedOption(option) ? theme.selectedOption : null,
                   component.isHighlightedOption(index) ? theme.highlightedOption : null,
+                  option.isDisabled ? theme.disabledOption : null,
                 ])}
-                onClick={(event) => component.handleClickOnOption(option.value, event)}
+                onClick={(event) => component.handleClickOnOption(option, event)}
                 onMouseEnter={() => component.setHighlightedOptionIndex(index)}
               >
                 {optionRenderer ? optionRenderer(option) : option.label}

--- a/source/themes/simple/SimpleSelect.scss
+++ b/source/themes/simple/SimpleSelect.scss
@@ -85,6 +85,7 @@ $select-option-padding: 14px 20px !default;
 
   &.disabledOption {
     color: rgba(#5e6066, 0.5);
+    cursor: default;
   }
 }
 

--- a/source/themes/simple/SimpleSelect.scss
+++ b/source/themes/simple/SimpleSelect.scss
@@ -82,6 +82,10 @@ $select-option-padding: 14px 20px !default;
   &.highlightedOption {
     background-color: $select-option-highlight-color;
   }
+
+  &.disabledOption {
+    color: rgba(#5e6066, 0.5);
+  }
 }
 
 // ======= SPECIAL STATES =======

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -24,6 +24,13 @@ const COUNTRIES_WITH_FLAGS = [
   { value: 'EN-en', label: 'USA', flag: flagUSA }
 ];
 
+const COUNTRIES_WITH_DISABLED_OPTIONS = [
+  { value: 'EN-gb', label: 'England' },
+  { value: 'ES-es', label: 'Spain' },
+  { value: 'TH-th', label: 'Thailand', isDisabled: true },
+  { value: 'EN-en', label: 'USA' }
+];
+
 storiesOf('Select', module)
 
   .addDecorator((story) => {
@@ -109,4 +116,13 @@ storiesOf('Select', module)
         isOpeningUpward
       />
     </div>
+  ))
+
+  .add('Countries - with disabled options', () => (
+    <Select
+      label="Countries (has disabled options)"
+      options={COUNTRIES_WITH_DISABLED_OPTIONS}
+      placeholder="Select your country …"
+      skin={<SimpleSelectSkin />}
+    />
   ));


### PR DESCRIPTION
This PR introduces the feature to render certain options as disabled (not selectable) in the `Select` component:

<img width="589" alt="screenshot 2017-05-29 um 12 43 20" src="https://cloud.githubusercontent.com/assets/172414/26548508/71fb6fde-446c-11e7-890d-d1a25a680f16.png">

It updates the mouse / key handling logic to make the option cycling respond correctly.