### PR TITLE
Fix/daef 265 swallowed number after dot bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-.babelrc
 .editorconfig
 stories
 storybook
-source

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "webpack": "^2.2.1"
   },
   "scripts": {
-    "js": "babel source --no-babelrc -d lib -s --presets=env,react --plugins=transform-flow-strip-types,transform-decorators-legacy,transform-class-properties,lodash",
-    "build": "cross-env npm run js && npm run sass",
+    "js": "babel source -d lib -s --no-babelrc --presets=env,react --plugins=transform-flow-strip-types,transform-decorators-legacy,transform-class-properties,lodash",
+    "build": "cross-env npm run clean && npm run js && npm run sass",
     "clean": "rimraf ./lib",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",

--- a/source/components/NumericInput.js
+++ b/source/components/NumericInput.js
@@ -43,6 +43,7 @@ export default class NumericInput extends FormField {
 
   componentDidUpdate (prevProps, prevState) {
     const input = this.skinParts[NumericInput.SKIN_PARTS.INPUT];
+    if (input !== document.activeElement) return;
 
     // caret position calculation after separators injection
     let caretPosition;

--- a/stories/NumericInput.stories.js
+++ b/stories/NumericInput.stories.js
@@ -102,4 +102,4 @@ storiesOf('NumericInput', module)
       minValue={0.000001}
       skin={<SimpleInputSkin />}
     />
-  ))
+  ));

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -31,5 +31,6 @@ module.exports = {
         ]
       }
     ]
-  }
+  },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
This PR fixes the "swallowed numer after dot" bug. Before if you entered `0.0001` char by char (including the dot) you would end up with `0.001` (notice there is one zero less after the dot).

It also fixes some other issue on the way that i found while testing it in Daedalus.